### PR TITLE
Update browser.sotez.js

### DIFF
--- a/src/browser.sotez.js
+++ b/src/browser.sotez.js
@@ -529,11 +529,11 @@ const rpc = {
     return rpc.sendOperation(from, operation, keys);
   },
   activate: (keys, secret) => {
-    const operation = {
+    const operation = [{
       kind: 'activate_account',
       pkh: keys.pkh,
       secret,
-    };
+    }];
     return rpc.sendOperation(keys.pkh, operation, keys);
   },
   originate: (keys, amount, code, init, spendable, delegatable, delegate, fee) => {


### PR DESCRIPTION
In all places where you set the variable of operation in order to utilize it in the rpc.sendOperation method you need to turn that object into an array with an object inside. Otherwise, operation won't be iterable when you use the spread operation for the variable ```ops``` in the rpc.sendOperation function.

      const operation = [{
      kind: 'activate_account',
      pkh: keys.pkh,
      secret,
    }]; 