### PR TITLE
Throw error if no public key retrieve

### DIFF
--- a/src/ledger-web.ts
+++ b/src/ledger-web.ts
@@ -33,7 +33,7 @@ const getAddress = async ({
     publicKey = await tezosLedger.getAddress(path, displayConfirm, curve);
   } catch (e) {
     transport.close();
-    return e;
+    throw e;
   }
   transport.close();
   return publicKey;

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -33,7 +33,7 @@ const getAddress = async ({
     publicKey = await tezosLedger.getAddress(path, displayConfirm, curve);
   } catch (e) {
     transport.close();
-    return e;
+    throw e;
   }
   transport.close();
   return publicKey;

--- a/src/tez.ts
+++ b/src/tez.ts
@@ -131,7 +131,11 @@ export default class Sotez extends AbstractTezModule {
       displayConfirm: true,
       curve,
     });
-
+    
+    if (!publicKey) {
+      throw new Error('Ledger not connected or no Tezos key available');
+    }
+    
     this.key = new Key(publicKey);
     await this.key.ready;
 


### PR DESCRIPTION
Unhandle error when importLedger() is retrieving empty {publicKey} object and crashing by creating new Key object.

Two conditions to do not retrieve Tezos address :
  - Ledger is not connecter
  - No Tezos address is present into ledger